### PR TITLE
Hardened SSH Service

### DIFF
--- a/etc/ssh/sshd_config
+++ b/etc/ssh/sshd_config
@@ -17,7 +17,7 @@ ListenAddress ::
 
 #HostKey /etc/ssh/ssh_host_rsa_key
 #HostKey /etc/ssh/ssh_host_ecdsa_key
-#HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_ed25519_key
 
 # Ciphers and keying
 #RekeyLimit default none
@@ -114,6 +114,11 @@ AcceptEnv LANG LC_*
 # override default of no subsystems
 #Subsystem	sftp	/usr/lib/openssh/sftp-server
 Subsystem       sftp    internal-sftp
+
+# Hardened set of key exchange, cipher, and MAC algorithms, as per <https://www.sshaudit.com/hardening_guides.html>.
+KexAlgorithms curve25519-sha256@libssh.org
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
 
 Match User root
         AuthenticationMethods publickey


### PR DESCRIPTION
This hardens the SSH service.  Namely:

- RSA host keys are disabled.  By default, 2048-bit keys are used, which only provide 112-bits of symmetric strength.  (These can be regenerated to 3072-bits [equivalent to 128-bits], but would require more setup effort.)
- ECDSA host keys are disabled, due to concerns that the NSA P-curves are compromised.
- Strong key exchange, cipher, and MAC algorithms are enabled only.

See [https://www.sshaudit.com/](https://www.sshaudit.com/) and the [ssh-audit command-line tool](https://github.com/arthepsy/ssh-audit).