### PR TITLE
 Disabling emulated parameters

### DIFF
--- a/var/www/html/admin.php
+++ b/var/www/html/admin.php
@@ -1,7 +1,7 @@
 <?php
 include('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }

--- a/var/www/html/delete.php
+++ b/var/www/html/delete.php
@@ -1,7 +1,7 @@
 <?php
 include('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }

--- a/var/www/html/files.php
+++ b/var/www/html/files.php
@@ -1,7 +1,7 @@
 <?php
 include('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }

--- a/var/www/html/home.php
+++ b/var/www/html/home.php
@@ -1,7 +1,7 @@
 <?php
 include('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }

--- a/var/www/html/list.php
+++ b/var/www/html/list.php
@@ -2,7 +2,7 @@
 header('Content-Type: text/html; charset=UTF-8');
 include_once('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }

--- a/var/www/html/log.php
+++ b/var/www/html/log.php
@@ -1,7 +1,7 @@
 <?php
 include('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }

--- a/var/www/html/login.php
+++ b/var/www/html/login.php
@@ -1,7 +1,7 @@
 <?php
 include('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);	
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }

--- a/var/www/html/password.php
+++ b/var/www/html/password.php
@@ -1,7 +1,7 @@
 <?php
 include('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }

--- a/var/www/html/register.php
+++ b/var/www/html/register.php
@@ -1,7 +1,7 @@
 <?php
 include('../common.php');
 try{
-	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT]);
+	$db=new PDO('mysql:host=' . DBHOST . ';dbname=' . DBNAME, DBUSER, DBPASS, [PDO::ATTR_ERRMODE=>PDO::ERRMODE_WARNING, PDO::ATTR_PERSISTENT=>PERSISTENT, PDO::ATTR_EMULATE_PREPARES=>false]);
 }catch(PDOException $e){
 	die('No Connection to MySQL database!');
 }


### PR DESCRIPTION
Emulated parameters can be vulnerable to SQL injection.
Take also a look here: https://stackoverflow.com/questions/134099/are-pdo-prepared-statements-sufficient-to-prevent-sql-injection

I'm working on the web interface and at the moment I'm not able to squash the commits.