### PR TITLE
Fixed a small typo

### DIFF
--- a/var/www/html/list.php
+++ b/var/www/html/list.php
@@ -18,7 +18,7 @@ $stmt=$db->query('SELECT COUNT(*) FROM users WHERE public=1;');
 $count=$stmt->fetch(PDO::FETCH_NUM);
 $stmt=$db->query('SELECT COUNT(*) FROM users WHERE public=0;');
 $hidden=$stmt->fetch(PDO::FETCH_NUM);
-echo "<p>Here a list of $count[0] public hosted sites ($hidden[0] sites hidden):</p>";
+echo "<p>Here is a list of $count[0] public hosted sites ($hidden[0] sites hidden):</p>";
 echo '<table border="1">';
 echo '<tr><td>Onion link</td></tr>';
 $stmt=$db->query('SELECT onions.onion FROM users INNER JOIN onions ON (onions.user_id=users.id) WHERE users.public=1 ORDER BY onions.onion;');


### PR DESCRIPTION
This PR fixes the typo "Here a list of 588 public hosted sites (172 sites hidden):" -> "Here is a list of 588 public hosted sites (172 sites hidden):" in the **list.php** file.