### PR TITLE
update Tor sources to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,16 @@ To get the latest mariadb version, you should follow these instructions to add t
 
 Add torproject to our repositories:
 ```
-curl -sSL https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc > /etc/apt/trusted.gpg.d/torproject.asc
-echo "deb https://deb.torproject.org/torproject.org `lsb_release -cs` main" >> /etc/apt/sources.list
+sudo apt install -y apt-transport-tor
+curl --socks5-hostname 127.0.0.1:9050 -sSL http://apow7mjfryruh65chtdydfmqfpj5btws7nbocgtaovhvezgccyjazpqd.onion/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc > /etc/apt/trusted.gpg.d/torproject.asc
+echo "deb tor://apow7mjfryruh65chtdydfmqfpj5btws7nbocgtaovhvezgccyjazpqd.onion/torproject.org/ `lsb_release -cs` main" >> /etc/apt/sources.list
 apt-get update && apt-get upgrade
 ```
 
 Note that both, debian and the torproject have hidden service package archives, so you may want to edit /etc/apt/sources.list to load from those instead:
 ```
 deb tor://vwakviie2ienjx6t.onion/debian `lsb_release -cs` main
-deb tor://sdscoq7snqtznauu.onion/torproject.org `lsb_release -cs` main
+deb tor://apow7mjfryruh65chtdydfmqfpj5btws7nbocgtaovhvezgccyjazpqd.onion/torproject.org `lsb_release -cs` main
 ```
 
 Copy (and modify according to your needs) the site files in `var/www` to `/var/www` and the configuration files in `etc` to `/etc` after installation has finished. Then restart some services:


### PR DESCRIPTION
Source of this commit:
* https://onion.torproject.org/
* http://xao2lxsmia2edq2n5zxg6uahx6xox2t7bfjw6b5vdzsxi7ezmqob6qid.onion/

Keep an eye for the v3 of Debian.
* https://onion.debian.org/

v2 deprecation timeline
* https://blog.torproject.org/v2-deprecation-timeline